### PR TITLE
added option chrome

### DIFF
--- a/admin/class-firefox-os-bookmark-admin.php
+++ b/admin/class-firefox-os-bookmark-admin.php
@@ -191,7 +191,9 @@ class Firefox_OS_Bookmark_Admin {
 		add_settings_field(
 				$this->plugin_slug . '_version', __( 'Version', $this->plugin_slug ), array( $this, 'field_version' ), $this->plugin_slug, 'ffos_bookmark_settings_manifest_section'
 		);
-
+		add_settings_field(
+				$this->plugin_slug . '_navigation', __( 'Navigation', $this->plugin_slug ), array( $this, 'field_navigation' ), $this->plugin_slug, 'ffos_bookmark_settings_manifest_section'
+		);
 		add_settings_section(
 				'ffos_bookmark_settings_icons_section', __( 'Icons Settings', $this->plugin_slug ), '__return_false', $this->plugin_slug
 		);
@@ -343,7 +345,20 @@ class Firefox_OS_Bookmark_Admin {
 
 		echo '<input type="text" name="' . $this->plugin_slug . '[version]" value="' . esc_attr( $setting[ 'version' ] ) . '" /> ' . __( 'Change if you update this page', $this->plugin_slug );
 	}
+	/**
+	 * Navigation
+	 *
+	 * @since    1.X
+	 */
+	function field_navigation() {
+		$setting = ( array ) get_option( $this->plugin_slug );
 
+		if ( !isset( $setting[ 'chrome' ] ) ) {
+			$setting['chrome'] = true;
+		}
+
+		echo '<input type="checkbox" name="' . $this->plugin_slug . '[chrome]" ' . checked( $setting[ 'chrome' ], 'on', false ) . ' />';
+	}
 	/**
 	 * Icon
 	 *

--- a/public/class-firefox-os-bookmark.php
+++ b/public/class-firefox-os-bookmark.php
@@ -362,6 +362,15 @@ class Firefox_OS_Bookmark {
 				$relative_path[ 'path' ] = "/";
 			}
 			$manifest[ 'launch_path' ] = $relative_path[ 'path' ];
+
+			//Replace now the chrome entry
+			if (isset( $manifest[ 'chrome'])) {
+				$chrome = $manifest[ 'chrome'];
+				unset($manifest[ 'chrome']);
+				$manifest[ 'chrome' ] = array('navigation' => true);
+			}
+			
+
 			//Clean JSON
 			$manifest_ready = str_replace( '\\', '', json_encode( $manifest ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Firefox OS Bookmark ===  
-Contributors: Mte90  
+Contributors: Mte90, _mr_moe  
 Donate link: http://mte90.net  
 Tags: mobile, bookmark, firefox os, firefox, open web app, manifest.webapp, webapp, firefox for android  
 Requires at least: 3.8  


### PR DESCRIPTION
Hi,

i have added a new option in the settings page to select the navigation - this will add in the manifest the chome:{navigation:true} option.
I had some problems with a app, which was rejected because of missing navigation options (this problem exists with the mobile theme from jetpack too btw)

I think this will help some people to get the app faster to the marketplace
